### PR TITLE
copy all properties present in a group

### DIFF
--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -72,10 +72,7 @@ export function optionAtIndex(originalCollection, index) {
 }
 
 function copyGroup(group, suboptions) {
-  let groupCopy = { groupName: group.groupName, options: suboptions };
-  if (group.hasOwnProperty('disabled')) {
-    groupCopy.disabled = group.disabled;
-  }
+  let groupCopy = { ...group, options: suboptions };
   return groupCopy;
 }
 

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -72,7 +72,19 @@ export function optionAtIndex(originalCollection, index) {
 }
 
 function copyGroup(group, suboptions) {
-  let groupCopy = { ...group, options: suboptions };
+  let groupCopy = { groupName: group.groupName, options: suboptions };
+  if (group.hasOwnProperty('disabled')) {
+    groupCopy.disabled = group.disabled;
+  }
+  if (group.hasOwnProperty('canSelect')) {
+    groupCopy.canSelect = group.canSelect;
+  }
+  if (group.hasOwnProperty('isAnyOptionSelected')) {
+    groupCopy.isAnyOptionSelected = group.isAnyOptionSelected;
+  }
+  if (group.hasOwnProperty('isAllOptionsSelected')) {
+    groupCopy.isAllOptionsSelected = group.isAllOptionsSelected;
+  }
   return groupCopy;
 }
 


### PR DESCRIPTION
Currently, power select only allows `groupName`, `options` , and `disabled` properties while returning search results.

This PR allows any other custom properties to be added.

Use case: If groups can be selected, the selected state is maintained via some property eg: `isSelected`. While returning search results, consumer will need `isSelected` as well