### PR TITLE
[PATCH] Sets false as the default value for animationEnabled property

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -56,7 +56,7 @@
   </dropdown.Trigger>
   <dropdown.Content
     @htmlTag={{this._ebdContentTagName}}
-    @animationEnabled={{@animationEnabled}}
+    @animationEnabled={{or @animationEnabled false}}
     class={{this.concatenatedDropdownClasses}}>
     {{#let (component this.beforeOptionsComponent) as |BeforeOptions|}}
       <BeforeOptions


### PR DESCRIPTION
**Description:**
- This fix is done because ember-basic-dropdown v2.x.x breaks when upgrading ember to v3.17. EBD fixes this in v3.x.x, to which ember-power-select upgrades to only in v4.x.x.
- So till we upgrade to ember-power-select 4.0.0, this patch will be required

**Related Issues:**
1. https://github.com/cibernox/ember-power-select/issues/1338
2. https://github.com/cibernox/ember-basic-dropdown/issues/540

**Dev Ticket:** https://dev.happyfox.co/staff/ticket/24395