### PR TITLE
Reapply patches on v4

### DIFF
--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -12,6 +12,7 @@
   @calculatePosition={{@calculatePosition}}
   @triggerComponent={{@ebdTriggerComponent}}
   @contentComponent={{@ebdContentComponent}}
+  @rootEventType={{or @eventType "mousedown"}}
   as |dropdown|>
   {{#let (assign dropdown (hash
     selected=this.selected

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -82,6 +82,7 @@ export interface PowerSelectArgs {
   onBlur?: (select: Select, event: FocusEvent) => void
   scrollTo?: (option: any, select: Select) => void
   registerAPI?: (select: Select) => void
+  allowGroupSearch?: boolean
 }
 
 const isArrayable = <T>(coll: any): coll is Arrayable<T> => {
@@ -552,7 +553,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   _filter(options: any[], term: string, skipDisabled = false): any[] {
     let matcher = this.args.matcher || defaultMatcher;
     let optionMatcher = getOptionMatcher(matcher, defaultMatcher, this.args.searchField);
-    return filterOptions(options || [], term, optionMatcher, skipDisabled);
+    return filterOptions(options || [], term, optionMatcher, skipDisabled, this.args.allowGroupSearch);
   }
 
   _updateIsActive(value: boolean) {

--- a/addon/utils/group-utils.ts
+++ b/addon/utils/group-utils.ts
@@ -72,11 +72,20 @@ export function optionAtIndex(originalCollection: any, index: number): { disable
   })(originalCollection, false) || { disabled: false, option: undefined };
 }
 
-interface Group { options: any[], disabled?: boolean, groupName: string }
+interface Group { options: any[], disabled?: boolean, groupName: string, [key: string]: any }
 function copyGroup(group: Group, suboptions: any[]): Group {
   let groupCopy: Group = { groupName: group.groupName, options: suboptions };
   if (group.hasOwnProperty('disabled')) {
     groupCopy.disabled = group.disabled;
+  }
+  if (group.hasOwnProperty('canSelect')) {
+    groupCopy.canSelect = group.canSelect;
+  }
+  if (group.hasOwnProperty('isAnyOptionSelected')) {
+    groupCopy.isAnyOptionSelected = group.isAnyOptionSelected;
+  }
+  if (group.hasOwnProperty('isAllOptionsSelected')) {
+    groupCopy.isAllOptionsSelected = group.isAllOptionsSelected;
   }
   return groupCopy;
 }
@@ -122,16 +131,21 @@ export function findOptionWithOffset(options: any, text: string, matcher: Matche
   return foundAfterOffset ? foundAfterOffset : foundBeforeOffset;
 }
 
-export function filterOptions(options: any, text: string, matcher: MatcherFn, skipDisabled = false): any[] {
+export function filterOptions(options: any, text: string, matcher: MatcherFn, skipDisabled = false, allowGroupSearch = false): any[] {
   let opts = A();
   let length = get(options, 'length');
   for (let i = 0; i < length; i++) {
     let entry = options.objectAt ? options.objectAt(i) : options[i];
     if (!skipDisabled || !get(entry, 'disabled')) {
       if (isGroup(entry)) {
-        let suboptions = filterOptions(get(entry, 'options'), text, matcher, skipDisabled);
-        if (get(suboptions, 'length') > 0) {
-          opts.push(copyGroup(entry, suboptions));
+        let groupName = get(entry, 'groupName');
+        if (allowGroupSearch && defaultMatcher(groupName, text) !== -1) {
+          opts.push(copyGroup(entry, entry.options));
+        } else {
+          let suboptions = filterOptions(get(entry, 'options'), text, matcher, skipDisabled);
+          if (get(suboptions, 'length') > 0) {
+            opts.push(copyGroup(entry, suboptions));
+          }
         }
       } else if (matcher(entry, text) >= 0) {
         opts.push(entry);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-power-select",
-  "version": "4.1.7",
+  "version": "4.1.7-hf.1",
   "description": "The extensible select component built for ember",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### Re-applied: Copy custom group properties (was PR #3)
- `addon/utils/group-utils.ts` — `Group` interface gets index signature; `copyGroup` explicitly carries `canSelect`, `isAnyOptionSelected`, `isAllOptionsSelected` through to search results

### Re-applied: Group search support (was PR #2)
- `addon/utils/group-utils.ts` — `filterOptions` gains `allowGroupSearch = false` param; when `true`, a group whose `groupName` matches the term is returned whole (all child options included) instead of recursing into children
- `addon/components/power-select.ts` — `PowerSelectArgs` adds `allowGroupSearch?: boolean`; `_filter` forwards it

```hbs
<PowerSelect @options={{this.grouped}} @allowGroupSearch={{true}} @onChange={{...}} as |opt|>
  {{opt}}
</PowerSelect>
```

### Re-applied: rootEventType (PR #1)

Why (PR #1) is not resolved when power select has exposed `@eventType` args with `mousedown` or `click` as possible values?
- v4.1.7 already ships `@eventType={{or @eventType "mousedown"}}` on the trigger — default behaviour is unchanged
- But our issue is due to `rootEventType` which is still not exposed by power-select because of which [ember-basic-dropdown resolves to click ](https://github.com/ember-power-addons/ember-basic-dropdown/blob/400a16ebadd62b211a187ed595e2eef51f541eb4/addon/templates/components/basic-dropdown.hbs#L32)